### PR TITLE
fix: correct UID and UDP ingress tuple handling

### DIFF
--- a/filter/signal-filter.bpf.c
+++ b/filter/signal-filter.bpf.c
@@ -319,7 +319,7 @@ int BPF_PROG(
 	u32 target_pid = p->pid;
 	u32 sender_pid = bpf_get_current_pid_tgid() >> 32;
 	u64 uid_gid = bpf_get_current_uid_gid();
-	u32 sender_uid = uid_gid >> 32; // Get UID from the high 32 bits
+	u32 sender_uid = uid_gid & 0xffffffff; // UID is stored in the low 32 bits
 
 	// Check rule filter mode
 	if (should_intercept_signal_by_rule(

--- a/filter/tc-process.bpf.c
+++ b/filter/tc-process.bpf.c
@@ -327,9 +327,8 @@ parse_sk_buff(struct sk_buff *skb, __u8 direction, struct net_group *tuple)
 		}
 		else
 		{ // INGRESS
-			// no need to convert
-			tuple->ip = (iph->daddr);
-			tuple->port = (udph->dest);
+			tuple->ip = bpf_ntohl(iph->daddr);
+			tuple->port = bpf_ntohs(udph->dest);
 		}
 	}
 	else if (iph->protocol == IPPROTO_TCP)
@@ -432,13 +431,13 @@ int BPF_KPROBE(security_socket_recvmsg, struct socket *sock, struct msghdr *msg)
 			__u32 *local_ip = bpf_map_lookup_elem(&local_ip_map, &key);
 			if (local_ip)
 			{
-				daddr = bpf_ntohl(*local_ip);
+				daddr = *local_ip;
 			}
 		}
 
 		struct net_group key = {};
 		key.ip = bpf_ntohl(daddr);
-		key.port = bpf_ntohs(dport);
+		key.port = dport;
 		key.protocol = IPPROTO_UDP;
 
 		struct ProcInfo proc = {};
@@ -457,7 +456,7 @@ int BPF_KPROBE(security_socket_recvmsg, struct socket *sock, struct msghdr *msg)
 
 		e->proc = proc;
 		e->net.ip = bpf_ntohl(daddr);
-		e->net.port = bpf_ntohs(dport);
+		e->net.port = dport;
 		e->net.protocol = IPPROTO_UDP;
 		e->flag = IP_AND_PORT;
 		e->timestamp = bpf_ktime_get_ns();


### PR DESCRIPTION
1.bpf_get_current_uid_gid() 的低 32 位是 UID，高 32 位是 GID。代码用 uid_gid >> 32 当 sender_uid，会导致 UID 规则匹配错误。
2.filter/tc-process.bpf.c:331 UDP ingress 没有转换 IP/port 字节序。但 filter/tc-process.bpf.c:440 存 tuple_map 时使用 host order。结果 UDP ingress lookup 很可能匹配不到进程。