### PR TITLE
fix: avoid duplicate loginuid records

### DIFF
--- a/observe/proc-info.bpf.c
+++ b/observe/proc-info.bpf.c
@@ -839,10 +839,6 @@ int dump_task(struct bpf_iter__task *ctx)
 	{
 		return 1;
 	}
-	if (dump_proc_loginuid(task))
-	{
-		return 1;
-	}
 	DEBUG(0, "dump_task: %d %s", task->pid, task->comm);
 
 	return 0;


### PR DESCRIPTION
This PR fixes the memory leak reported in issue #11.  
Closes #11 