### PR TITLE
fix: umount flags cannot be counted.

### DIFF
--- a/observe/mountsnoop.bpf.c
+++ b/observe/mountsnoop.bpf.c
@@ -691,13 +691,10 @@ static void save_umount_args(struct syscall_trace_enter *ctx)
 {
 	long ret;
 	const char __user *target;
-	unsigned int flags = 0;
+	unsigned int flags;
 
 	target = (const char *)ctx->args[0];
-	if (ctx->nr == 2)
-	{
-		flags = (unsigned int)ctx->args[1];
-	}
+	flags = (unsigned int)ctx->args[1];
 
 	pid_t pid = bpf_get_current_pid_tgid();
 	ret = bpf_map_update_elem(&umount_map, &pid, &zero_map_item, BPF_ANY);
@@ -711,7 +708,7 @@ static void save_umount_args(struct syscall_trace_enter *ctx)
 	args = bpf_map_lookup_elem(&umount_map, &pid);
 	if (!args)
 	{
-		bpf_err("bpf_map_update_elem fail: %ld", ret);
+		bpf_err("bpf_map_lookup_elem fail: %ld", ret);
 		return;
 	}
 	bpf_read_ustr(args->target, sizeof(args->target), target);
@@ -727,7 +724,7 @@ static void save_umount_ret(int ret)
 	args = bpf_map_lookup_elem(&umount_map, &pid);
 	if (!args)
 	{
-		bpf_err("bpf_map_update_elem fail: %ld", ret);
+		bpf_err("bpf_map_lookup_elem fail: %ld", ret);
 		return;
 	}
 	args->ret = ret;


### PR DESCRIPTION
1.struct syscall_trace_enter 里的 ctx->nr 是系统调用号，不是参数数量，所以 flags 无法被 save，args 是 tracepoint 上固定的参数数组。
当前程序只挂在：
SEC("tracepoint/syscalls/sys_enter_umount")
所以它对应的就是 umount 入口，第二个参数 flags 应该直接从 ctx->args[1] 获取。
2.修复部分打印语义错误。

Closed #15 