### PR TITLE
fix: add missing break after IPPROTO_ICMP to prevent fallthrough to IPPROTO_ICMPV6

### DIFF
--- a/filter/net-filter.bpf.c
+++ b/filter/net-filter.bpf.c
@@ -474,6 +474,7 @@ static bool parse_sk_buff(struct sk_buff *skb, struct BpfData *log)
 		log->tuple.sport = icmph->un.echo.id;
 		log->tuple.dport = icmph->un.echo.id;
 		debug_tuple(&log->tuple, "NF-ICMP", DEBUG_NF_ICMP_PKG);
+		break;
 	case IPPROTO_ICMPV6:
 		icmp6h = icmp6_hdr(skb, iphl);
 		if (icmp6h == NULL)
@@ -868,6 +869,7 @@ static bool parse_sock(struct socket *sock, struct BpfData *log)
 		break;
 	case IPPROTO_ICMP:
 		debug_tuple(&log->tuple, "LSM-ICMP", DEBUG_LSM_ICMP_PKG);
+		break;
 	case IPPROTO_ICMPV6:
 		debug_tuple(&log->tuple, "LSM-ICMPv6", DEBUG_LSM_ICMP_PKG);
 		break;


### PR DESCRIPTION
Both parse_sk_buff() and parse_sock() in filter/net-filter.bpf.c were missing
break statements after the IPPROTO_ICMP case in their switch blocks. This caused
ICMP packets to incorrectly fall through to the IPPROTO_ICMPV6 handling code,
overwriting the log fields (port, data_len) with ICMPv6 values.

Fix: add break; after the IPPROTO_ICMP branch in both functions.