### PR TITLE
bpf: preprocess BPF objects during object build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,22 +3,39 @@
 # SPDX-License-Identifier: LGPL-2.1
 
 BUILD_DIR = build
-TARGETs = include observe filter policy
+TARGETs = include tools observe filter policy
 SUBTARGETs = $(foreach i,$(TARGETs),$(i)/%)
-MAKE = make PROJ_ROOT=$(shell pwd)
+KHEADERS_DIR ?= /lib/modules/$(shell uname -r)/build/include
+PWD = $(shell pwd)
+
+BPF_TARGET_ARCH := $(shell uname -m)
+ifeq ($(BPF_TARGET_ARCH), loongarch64)
+	BPF_TARGET_ARCH := loongarch
+endif
+
+BPF_PREPROCESS ?= $(PWD)/build/tools/extern-prep
+
+MAKE_FLAGS += "PROJ_ROOT=$(PWD)"
+MAKE_FLAGS += "BPF_TARGET_ARCH=$(BPF_TARGET_ARCH)"
+MAKE_FLAGS += "BPF_PREPROCESS=$(BPF_PREPROCESS)"
+MAKE_FLAGS += "KHEADERS_DIR=$(KHEADERS_DIR)"
+MAKE += $(MAKE_FLAGS)
 
 .PHONY: all clean distclean pseudo $(TARGETs)
 .SUFFIXES:
 
 all: $(TARGETs)
 
-observe filter policy: include
+observe filter policy: include tools
 
 $(TARGETs):
 	$(MAKE) -C $@
 
-$(SUBTARGETs): pseudo
-	$(MAKE)  $* -C $(shell dirname $@)
+$(SUBTARGETs): pseudo | $(BPF_PREPROCESS)
+	$(MAKE) $* -C $(shell dirname $@)
+
+$(BPF_PREPROCESS): 
+	$(MAKE) -C $(PWD)/tools $@
 
 pseudo:
 

--- a/filter/Makefile
+++ b/filter/Makefile
@@ -7,14 +7,13 @@ MODULE := $(notdir $(CURDIR))
 BUILD_DIR := $(PROJ_ROOT)/build/$(MODULE)
 BPF_SRC = $(shell ls *.bpf.c)
 TARGETs = $(BPF_SRC:%.bpf.c=$(BUILD_DIR)/%.bpf.o)
-BPF_TARGET_ARCH := $(shell uname -m)
-ifeq ($(BPF_TARGET_ARCH), loongarch64)
-	BPF_TARGET_ARCH := loongarch
-endif
 CLANG_FLAGS = -g -MMD -Wall -O2 \
+			-D__$(BPF_TARGET_ARCH)__ \
 			-I$(PROJ_ROOT)/include \
 			-I$(PROJ_ROOT)/export/ \
-			-I$(PROJ_ROOT)/build/include
+			-I$(PROJ_ROOT)/build/include \
+			-I/usr/include/$(shell uname -m)-linux-gnu/ \
+			-I$(KHEADERS_DIR)
 
 .PHONY: all clean
 # 注明不要删除的中间文件
@@ -28,13 +27,12 @@ $(BUILD_DIR):
 	@mkdir -p $@
 
 $(BUILD_DIR)/%.bpf.o: %.bpf.c $(PROJ_ROOT)/build/include/vmlinux.h $(PROJ_ROOT)/build/include/kconfig.h | $(BUILD_DIR)
-	clang -D__$(BPF_TARGET_ARCH)__ $(CLANG_FLAGS) -target bpf -c $< -o $@
+	clang $(CLANG_FLAGS) -target bpf -c $< -o $@
+	$(BPF_PREPROCESS) $@ $@.tmp
+	mv $@.tmp $@
 
-$(PROJ_ROOT)/build/include/vmlinux.h:
-	make -C $(PROJ_ROOT)/include/ $@
-
-$(PROJ_ROOT)/build/include/kconfig.h:
-	make -C $(PROJ_ROOT)/include/ $@
+$(PROJ_ROOT)/build/include/vmlinux.h $(PROJ_ROOT)/build/include/kconfig.h:
+	$(MAKE) -C $(PROJ_ROOT)/include $@
 
 built-in.a:
 	clang -r $(BUILD_DIR)/*.bpf.o -o $@

--- a/observe/Makefile
+++ b/observe/Makefile
@@ -7,12 +7,8 @@ MODULE := $(notdir $(CURDIR))
 BUILD_DIR := $(PROJ_ROOT)/build/$(MODULE)
 BPF_SRC = $(shell ls *.bpf.c)
 TARGETs = $(BPF_SRC:%.bpf.c=$(BUILD_DIR)/%.bpf.o)
-BPF_TARGET_ARCH := $(shell uname -m)
-ifeq ($(BPF_TARGET_ARCH), loongarch64)
-	BPF_TARGET_ARCH := loongarch
-endif
-KHEADERS_DIR ?= /lib/modules/$(shell uname -r)/build/include
 CLANG_FLAGS = -g -MMD -Wall -O2 \
+			-D__$(BPF_TARGET_ARCH)__ \
 			-I$(PROJ_ROOT)/include \
 			-I$(PROJ_ROOT)/export/ \
 			-I$(PROJ_ROOT)/build/include \
@@ -31,13 +27,12 @@ $(BUILD_DIR):
 	@mkdir -p $@
 
 $(BUILD_DIR)/%.bpf.o: %.bpf.c $(PROJ_ROOT)/build/include/vmlinux.h $(PROJ_ROOT)/build/include/kconfig.h | $(BUILD_DIR)
-	clang -D__$(BPF_TARGET_ARCH)__ $(CLANG_FLAGS) -target bpf -c $< -o $@
+	clang $(CLANG_FLAGS) -target bpf -c $< -o $@
+	$(BPF_PREPROCESS) $@ $@.tmp
+	mv $@.tmp $@
 
-$(PROJ_ROOT)/build/include/vmlinux.h:
-	make -C $(PROJ_ROOT)/include/ $@
-
-$(PROJ_ROOT)/build/include/kconfig.h:
-	make -C $(PROJ_ROOT)/include/ $@
+$(PROJ_ROOT)/build/include/vmlinux.h $(PROJ_ROOT)/build/include/kconfig.h:
+	$(MAKE) -C $(PROJ_ROOT)/include $@
 
 built-in.a:
 	clang -r $(BUILD_DIR)/*.bpf.o -o $@

--- a/policy/Makefile
+++ b/policy/Makefile
@@ -7,12 +7,8 @@ MODULE := $(notdir $(CURDIR))
 BUILD_DIR := $(PROJ_ROOT)/build/$(MODULE)
 BPF_SRC = $(shell ls *.bpf.c)
 TARGETs = $(BPF_SRC:%.bpf.c=$(BUILD_DIR)/%.bpf.o)
-BPF_TARGET_ARCH := $(shell uname -m)
-ifeq ($(BPF_TARGET_ARCH), loongarch64)
-	BPF_TARGET_ARCH := loongarch
-endif
-KHEADERS_DIR ?= /lib/modules/$(shell uname -r)/build/include
 CLANG_FLAGS = -g -MMD -Wall -O2 \
+			-D__$(BPF_TARGET_ARCH)__ \
 			-I$(PROJ_ROOT)/include \
 			-I$(PROJ_ROOT)/export/ \
 			-I$(PROJ_ROOT)/build/include \
@@ -31,13 +27,12 @@ $(BUILD_DIR):
 	@mkdir -p $@
 
 $(BUILD_DIR)/%.bpf.o: %.bpf.c $(PROJ_ROOT)/build/include/vmlinux.h $(PROJ_ROOT)/build/include/kconfig.h | $(BUILD_DIR)
-	clang -D__$(BPF_TARGET_ARCH)__ $(CLANG_FLAGS) -target bpf -c $< -o $@
+	clang $(CLANG_FLAGS) -target bpf -c $< -o $@
+	$(BPF_PREPROCESS) $@ $@.tmp
+	mv $@.tmp $@
 
-$(PROJ_ROOT)/build/include/vmlinux.h:
-	make -C $(PROJ_ROOT)/include/ $@
-
-$(PROJ_ROOT)/build/include/kconfig.h:
-	make -C $(PROJ_ROOT)/include/ $@
+$(PROJ_ROOT)/build/include/vmlinux.h $(PROJ_ROOT)/build/include/kconfig.h:
+	$(MAKE) -C $(PROJ_ROOT)/include $@
 
 built-in.a:
 	clang -r $(BUILD_DIR)/*.bpf.o -o $@

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd
+#
+# SPDX-License-Identifier: LGPL-2.1
+
+PROJ_ROOT ?= ..
+MODULE := $(notdir $(CURDIR))
+BUILD_DIR = $(PROJ_ROOT)/build/$(MODULE)
+
+LDFLAGS := -lelf -lz -lbpf -lpthread
+
+.PHONY: all clean extern-prep
+
+all: $(BUILD_DIR)/extern-prep
+
+$(BUILD_DIR)/extern-prep: extern-prep.cpp btf-preprocessor.cpp btf-preprocessor.h | $(BUILD_DIR)
+	$(CXX) -o $@ extern-prep.cpp btf-preprocessor.cpp $(LDFLAGS)
+
+extern-prep: $(BUILD_DIR)/extern-prep
+
+$(BUILD_DIR):
+	@mkdir -p $@
+
+clean:
+	rm -rf $(BUILD_DIR)

--- a/tools/btf-preprocessor.cpp
+++ b/tools/btf-preprocessor.cpp
@@ -1,0 +1,519 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd
+//
+// SPDX-License-Identifier: LGPL-2.1
+
+#include <cstdio>
+#include <cstring>
+#include <cerrno>
+#include <cstdlib>
+
+#include <unistd.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+#include <libelf.h>
+#include <gelf.h>
+#include <bpf/btf.h>
+#include <bpf/libbpf.h>
+
+#include "btf-preprocessor.h"
+
+#define SHN_UNDEF 0       // ELF 符号未定义（extern）
+#define STB_GLOBAL 1      // ELF 符号全局绑定
+#define STT_NOTYPE 0      // ELF 符号无类型
+#define STT_OBJECT 1      // ELF 符号是数据对象
+#ifndef ELF64_ST_INFO
+#define ELF64_ST_INFO(b, t) (((b) << 4) + ((t) & 0xF))  // 组装绑定+类型
+#endif
+
+// 用 btf__parse_elf 直接解析 ELF 中的 BTF
+int BtfPreprocessor::check_extern_maps(
+    const char *bpf_obj_path, 
+    std::vector<ExternMapInfo> *ext_info)
+{
+    struct btf *btf = btf__parse_elf(bpf_obj_path, NULL);
+    
+    if (!btf) { 
+        m_last_error = "failed to parse BTF"; 
+        return -EINVAL; 
+    }
+
+    auto add = [&](int vid, int tid, const char *n, const char *tn) {
+         ExternMapInfo e; 
+         e.name=n; 
+         e.btf_var_id=vid;
+         e.btf_type_id=tid; 
+         e.type_name=tn?tn:""; 
+         ext_info->push_back(e);
+    };
+
+    // 优先查 .maps DATASEC 中的 extern 变量
+    int sid = btf__find_by_name_kind(btf, ".maps", BTF_KIND_DATASEC);
+    if (sid >= 0) {
+        const struct btf_type *sec = btf__type_by_id(btf, sid);
+        const struct btf_var_secinfo *inf = btf_var_secinfos(sec);
+        for (int i = 0; i < btf_vlen(sec); i++) {
+            const struct btf_type *v = btf__type_by_id(btf, inf[i].type);
+            if (!v||!btf_is_var(v)) continue;
+            if (btf_var(v)->linkage!=BTF_VAR_GLOBAL_EXTERN) continue;
+            const char *n = btf__name_by_offset(btf, v->name_off); if(!n) continue;
+            const char *tn=""; auto p=btf__type_by_id(btf,v->type); if(p) tn=btf__name_by_offset(btf,p->name_off)?:"";
+            add(inf[i].type, v->type, n, tn);
+        }
+    } else {
+        // 无 .maps DATASEC：扫描所有 extern struct 类型变量
+        int nt = btf__type_cnt(btf);
+        for (int t = 1; t < nt; t++) {
+            const struct btf_type *x = btf__type_by_id(btf, t);
+            if (!x||!btf_is_var(x)) continue;
+            if (btf_var(x)->linkage!=BTF_VAR_GLOBAL_EXTERN) continue;
+            const char *n = btf__name_by_offset(btf, x->name_off); if(!n||!n[0]) continue;
+            auto val = btf__type_by_id(btf, x->type); if(!val||!btf_is_composite(val)) continue;
+            add(t, x->type, n, btf__name_by_offset(btf,val->name_off));
+        }
+    }
+    btf__free(btf); return 0;
+}
+
+// 完整的 ELF 手术：
+// 1. BTF linkage EXTERN → ALLOCATED + 添加 .maps DATASEC
+// 2. 拷贝输入文件到输出
+// 3. libelf 打开输出 → 创建 .maps section + 修复符号表 + 替换 BTF 数据
+int BtfPreprocessor::preprocess(
+    const char *input_path, const char *output_path,
+    std::vector<ExternVarInfo> *ext_vars)
+{
+    // ── 第 1 步：BTF 预处理 ─────────────────────────────────
+
+    // 解析 BTF，记录 extern map 信息
+    struct btf *btf = btf__parse_elf(input_path, NULL);
+    if (!btf) { m_last_error = "failed to parse BTF"; return -EINVAL; }
+    std::vector<ExternVarInfo> lv;
+    int e = count_extern_and_get_info(btf, &lv);
+    if (e) { btf__free(btf); return e; }
+    if (lv.empty()) { btf__free(btf); return copy_file(input_path, output_path); }
+
+    // 将 linkage 从 GLOBAL_EXTERN 改为 GLOBAL_ALLOCATED
+    // 注意：btf__type_by_id 返回 const，但 libbpf 未提供修改 linkage 的公开 API，
+    // 此处修改后立即通过 btf__raw_data 取出再 btf__free，不会与 libbpf 内部操作冲突
+    for (auto &v : lv) {
+        auto t = btf__type_by_id(btf, v.var_btf_id);
+        if (t) {
+            btf_var((struct btf_type *)t)->linkage = BTF_VAR_GLOBAL_ALLOCATED;
+        }
+    }
+
+    // 提取修改后的裸 BTF 数据（linkage 已改）
+    const void *rb;
+    __u32 rsz;
+    rb = btf__raw_data(btf, &rsz);
+    if (!rb||!rsz) { btf__free(btf); m_last_error="btf__raw_data failed"; return -EINVAL; }
+    void *bc = malloc(rsz); if (!bc) { btf__free(btf); return -ENOMEM; }
+    memcpy(bc, rb, rsz);
+    btf__free(btf);
+
+    // ── 第 2 步：拷贝文件 + libelf 打开 ─────────────────────
+
+    e = copy_file(input_path, output_path);
+    if (e) { free(bc); return e; }
+    int fd = open(output_path, O_RDWR);
+    if (fd < 0) { free(bc); return -errno; }
+    elf_version(EV_CURRENT);
+    Elf *elf = elf_begin(fd, ELF_C_RDWR, NULL);
+    if (!elf) { close(fd); free(bc); m_last_error="elf_begin failed"; return -EINVAL; }
+
+    size_t shstrndx;
+    if (elf_getshdrstrndx(elf, &shstrndx) != 0) {
+        elf_end(elf); close(fd); free(bc);
+        m_last_error="elf_getshdrstrndx failed"; return -EINVAL;
+    }
+
+    // ── 第 3 步：定位 .BTF 和 .symtab section ──────────────
+
+    Elf_Scn *btf_scn=nullptr, *symtab_scn=nullptr;
+    int symtab_link = 0;
+    Elf_Scn *scn = nullptr;
+    while ((scn = elf_nextscn(elf, scn)) != nullptr) {
+        GElf_Shdr sh; gelf_getshdr(scn, &sh);
+        const char *n = elf_strptr(elf, shstrndx, sh.sh_name);
+        if (!n) continue;
+        if (strcmp(n,".BTF")==0) btf_scn=scn;
+        if (strcmp(n,".symtab")==0) { symtab_scn=scn; symtab_link=sh.sh_link; }
+    }
+    if (!btf_scn||!symtab_scn) {
+        elf_end(elf); close(fd); free(bc);
+        m_last_error=".BTF or .symtab not found"; return -ENOENT;
+    }
+
+    // ── 第 4 步：查找或创建 .maps ELF section ────────────────
+
+    // 计算 extern 转换后需要的数据大小
+    size_t extern_sz = 0;
+    for (auto &v : lv) {
+        v.offset = extern_sz;
+        extern_sz += (v.struct_size < 16) ? 16 : v.struct_size;
+    }
+    if (extern_sz == 0) extern_sz = 16;
+
+    // 查找已有 .maps section（BPF 代码中同时有定义 + extern 时存在）
+    Elf_Scn *maps_scn = nullptr;
+    size_t maps_existing_sz = 0;
+    bool has_existing_maps = false;
+    Elf_Scn *s = nullptr;
+    while ((s = elf_nextscn(elf, s)) != nullptr) {
+        GElf_Shdr sh; gelf_getshdr(s, &sh);
+        const char *n = elf_strptr(elf, shstrndx, sh.sh_name);
+        if (n && strcmp(n, ".maps") == 0) {
+            maps_scn = s;
+            maps_existing_sz = sh.sh_size;
+            has_existing_maps = true;
+            break;
+        }
+    }
+
+    if (!maps_scn) {
+        // 无已有 .maps section → 新建
+        maps_scn = elf_newscn(elf);
+        if (!maps_scn) { elf_end(elf); close(fd); free(bc); m_last_error="elf_newscn failed"; return -EINVAL; }
+
+        // 将 ".maps" 名称注册到 section header string table
+        size_t maps_name_off = 0;
+        Elf_Scn *shstrtab_scn = elf_getscn(elf, shstrndx);
+        if (shstrtab_scn) {
+            Elf_Data *sd = elf_getdata(shstrtab_scn, nullptr);
+            if (sd && sd->d_buf) {
+                const char *needle = ".maps";
+                size_t slen = strlen(needle) + 1;
+                const char *p = (const char *)sd->d_buf;
+                int found = 0;
+                if (sd->d_size >= slen) {
+                    for (size_t i = 0; i < sd->d_size - slen; i++) {
+                        if (memcmp(p + i, needle, slen) == 0) {
+                            maps_name_off = i; found = 1; break;
+                        }
+                    }
+                }
+                if (!found) {
+                    // sd->d_buf 由 libelf 管理，不能 realloc；必须 malloc + memcpy
+                    void *nb = malloc(sd->d_size + slen);
+                    if (!nb) { elf_end(elf); close(fd); free(bc); return -ENOMEM; }
+                    memcpy(nb, sd->d_buf, sd->d_size);
+                    memcpy((char *)nb + sd->d_size, needle, slen);
+                    maps_name_off = sd->d_size;
+                    sd->d_buf = nb;
+                    sd->d_size += slen;
+                    GElf_Shdr ssh; gelf_getshdr(shstrtab_scn, &ssh);
+                    ssh.sh_size = sd->d_size;
+                    gelf_update_shdr(shstrtab_scn, &ssh);
+                }
+            }
+        }
+
+        GElf_Shdr msh; memset(&msh, 0, sizeof(msh));
+        msh.sh_name = maps_name_off;
+        msh.sh_type = SHT_PROGBITS;
+        msh.sh_flags = SHF_WRITE | SHF_ALLOC;
+        msh.sh_size = extern_sz;
+        msh.sh_addralign = 4;
+        gelf_update_shdr(maps_scn, &msh);
+    } else {
+        // 已有 .maps section → 扩展现有数据 buffer，末尾追加零填充
+        // 取出已有的数据描述符，将 d_buf 重新分配为更大尺寸
+        Elf_Data *existing = elf_getdata(maps_scn, nullptr);  /* <libelf.h> */
+        if (!existing) {
+            elf_end(elf); close(fd); free(bc);
+            m_last_error = "elf_getdata(.maps) returned NULL"; return -EINVAL;
+        }
+        // 旧 d_buf 由 libelf 管理，不能 realloc（会导致 elf_end 时 double-free）；
+        // 必须 malloc 新 buffer + memcpy 旧数据，旧 buffer 泄漏（一次性的构建工具可接受）
+        void *new_buf = malloc(maps_existing_sz + extern_sz);  /* <stdlib.h> */
+        if (!new_buf) {
+            elf_end(elf); close(fd); free(bc);
+            m_last_error = "malloc for .maps append failed"; return -ENOMEM;
+        }
+        memcpy(new_buf, existing->d_buf, maps_existing_sz);  /* <string.h> */
+        memset((char *)new_buf + maps_existing_sz, 0, extern_sz);  /* <string.h> */
+        existing->d_buf = new_buf;
+        existing->d_size = maps_existing_sz + extern_sz;
+        elf_flagdata(existing, ELF_C_SET, ELF_F_DIRTY);  /* <libelf.h> */
+
+        GElf_Shdr msh; gelf_getshdr(maps_scn, &msh);
+        msh.sh_size = maps_existing_sz + extern_sz;
+        gelf_update_shdr(maps_scn, &msh);  /* <gelf.h> */
+    }
+
+    // 新建分支：写入零填充的 extern map 数据（已有分支已在上方处理）
+    if (!has_existing_maps) {
+        Elf_Data *md = elf_newdata(maps_scn);  /* <libelf.h> */
+        if (md) {
+            md->d_buf = calloc(1, extern_sz);  /* <stdlib.h> */
+            md->d_size = extern_sz;
+            md->d_type = ELF_T_BYTE;
+            md->d_version = EV_CURRENT;  /* <libelf.h> */
+        }
+    }
+
+    size_t maps_shndx = elf_ndxscn(maps_scn);
+
+    // ── 第 5 步：修复符号表 ──────────────────────────────────
+    // 将 SHN_UNDEF 的 extern 符号改为指向新建的 .maps section
+
+    Elf_Data *symd = elf_getdata(symtab_scn, nullptr);
+    if (symd && symd->d_buf && symd->d_size > 0) {
+        int nsym = symd->d_size / sizeof(Elf64_Sym);
+        Elf64_Sym *syms = (Elf64_Sym *)symd->d_buf;
+        for (int i = 0; i < nsym; i++) {
+            if (syms[i].st_shndx != SHN_UNDEF) continue;
+            const char *sn = elf_strptr(elf, symtab_link, syms[i].st_name);
+            if (!sn) continue;
+            for (auto &v : lv) {
+                if (strcmp(sn, v.name.c_str()) == 0) {
+                    // 从 STT_NOTYPE 改为 STT_OBJECT，从 SHN_UNDEF 改为 .maps
+                    syms[i].st_info = ELF64_ST_INFO(STB_GLOBAL, STT_OBJECT);
+                    syms[i].st_shndx = maps_shndx;
+                    syms[i].st_value = v.offset;
+                    syms[i].st_size = v.struct_size;
+                    fprintf(stdout, "  [prep] '%s' -> .maps[%zu] size=%d\n",
+                            sn, maps_shndx, v.struct_size);
+                    break;
+                }
+            }
+        }
+    }
+
+    // ── 第 6 步：替换 .BTF section 数据 ──────────────────────
+    // 将修改后的 BTF 写回 ELF
+    //
+    // elf_getdata 返回的 Elf_Data 中 d_buf 由 libelf 管理，
+    // 不能 free/realloc；必须用 elf_rawdata 或 elf_resizesection 调整大小。
+    // 当新 BTF 比旧 BTF 大时，用 elf_resize 扩展 .BTF section，
+    // 然后重新取 data 描述符再写入。
+
+    Elf_Data *bd = elf_getdata(btf_scn, nullptr);
+    if (!bd) {
+        elf_end(elf); close(fd); free(bc);
+        m_last_error = "elf_getdata(.BTF) returned NULL"; return -EINVAL;
+    }
+    if (bd->d_size >= rsz) {
+        // 新 BTF 不超过旧 buffer，直接覆盖
+        memcpy(bd->d_buf, bc, rsz);
+        bd->d_size = rsz;
+        elf_flagdata(bd, ELF_C_SET, ELF_F_DIRTY);
+    } else {
+        // 新 BTF 超出旧 buffer 大小
+        // libelf 没有跨版本通用的 section resize API，
+        // 直接替换 d_buf 为新分配的 buffer，elf_end 时由 libelf 释放。
+        // 旧 bd->d_buf 的内存由 libelf 管理，替换后泄漏（一次性的构建工具可接受）。
+        void *new_buf = malloc(rsz);  /* <stdlib.h> */
+        if (!new_buf) {
+            elf_end(elf); close(fd); free(bc);
+            m_last_error = "malloc failed for BTF resize"; return -ENOMEM;
+        }
+        memcpy(new_buf, bc, rsz);  /* <string.h> */
+        bd->d_buf = new_buf;
+        bd->d_size = rsz;
+        elf_flagdata(bd, ELF_C_SET, ELF_F_DIRTY);  /* <libelf.h> */
+    }
+    GElf_Shdr bsh; gelf_getshdr(btf_scn, &bsh);
+    bsh.sh_size = rsz;
+    gelf_update_shdr(btf_scn, &bsh);
+
+    // ── 第 6.5 步：创建 .extern_map_names ELF section ────────
+    // 将 extern map 名存储为自定义 ELF section，运行时供
+    // bpf_linker_resolve_extern() 读取，避免修改 BTF 导致的
+    // .rel.BTF 损坏
+    {
+        std::string data;
+        for (auto &v : lv) {
+            if (!data.empty()) data += '\0';
+            data += v.name;
+        }
+        if (!data.empty()) data += '\0';
+
+        Elf_Scn *ext_scn = elf_newscn(elf);
+        if (ext_scn) {
+            size_t name_off = 0;
+            Elf_Scn *shstrtab_scn = elf_getscn(elf, shstrndx);
+            if (shstrtab_scn) {
+                Elf_Data *sd = elf_getdata(shstrtab_scn, nullptr);
+                if (sd && sd->d_buf) {
+                    const char *needle = ".extern_map_names";
+                    size_t slen = strlen(needle) + 1;
+                    const char *p = (const char *)sd->d_buf;
+                    int found = 0;
+                    if (sd->d_size >= slen) {
+                        for (size_t i = 0; i < sd->d_size - slen; i++) {
+                            if (memcmp(p + i, needle, slen) == 0) {
+                                name_off = i; found = 1; break;
+                            }
+                        }
+                    }
+                    if (!found) {
+                        void *nb = malloc(sd->d_size + slen);
+                        if (nb) {
+                            memcpy(nb, sd->d_buf, sd->d_size);
+                            memcpy((char *)nb + sd->d_size,
+                                   needle, slen);
+                            name_off = sd->d_size;
+                            sd->d_buf = nb;
+                            sd->d_size += slen;
+                            GElf_Shdr ssh; gelf_getshdr(shstrtab_scn,
+                                                         &ssh);
+                            ssh.sh_size = sd->d_size;
+                            gelf_update_shdr(shstrtab_scn, &ssh);
+                        }
+                    }
+                }
+            }
+
+            Elf_Data *ed = elf_newdata(ext_scn);
+            if (ed) {
+                ed->d_buf = malloc(data.size());
+                if (ed->d_buf) {
+                    memcpy(ed->d_buf, data.data(), data.size());
+                    ed->d_size = data.size();
+                    ed->d_type = ELF_T_BYTE;
+                }
+            }
+
+            GElf_Shdr esh; memset(&esh, 0, sizeof(esh));
+            esh.sh_name = name_off;
+            esh.sh_type = SHT_PROGBITS;
+            esh.sh_flags = 0;
+            esh.sh_size = data.size();
+            esh.sh_addralign = 1;
+            gelf_update_shdr(ext_scn, &esh);
+        }
+    }
+
+    // ── 第 7 步：写入磁盘 ────────────────────────────────────
+
+    if (elf_update(elf, ELF_C_WRITE) < 0) {
+        elf_end(elf); close(fd); free(bc);
+        m_last_error = "elf_update failed"; return -EINVAL;
+    }
+    elf_end(elf); close(fd); free(bc);
+
+    int n = lv.size();
+    if (ext_vars) *ext_vars = std::move(lv);
+    fprintf(stdout, "  [prep] %d extern map(s) converted\n", n);
+    return n;
+}
+
+// 遍历 BTF 类型链，跳过 CONST/VOLATILE/TYPEDEF，返回最终类型 ID
+static int btf_resolve_type(struct btf *btf, int type_id)
+{
+	int id = type_id;
+	for (int i = 0; i < 32; i++) {  // 防止无限循环
+		const struct btf_type *t = btf__type_by_id(btf, id);
+		if (!t) break;
+		if (btf_is_const(t) || btf_is_volatile(t) || btf_is_typedef(t))
+			id = t->type;
+		else
+			break;
+	}
+	return id;
+}
+
+// 从 extern var 的 struct 类型中提取 map 元数据
+static void fill_map_metadata(struct btf *btf, int struct_type_id,
+			      int *map_type, int *key_size,
+			      int *value_size, int *max_entries)
+{
+	const struct btf_type *st = btf__type_by_id(btf, struct_type_id);
+	if (!st || !btf_is_composite(st)) return;
+
+	const struct btf_member *members = btf_members(st);
+	int vlen = btf_vlen(st);
+	for (int i = 0; i < vlen; i++) {
+		const char *name = btf__name_by_offset(btf, members[i].name_off);
+		if (!name) continue;
+
+		int mtype = members[i].type;
+		if (strcmp(name, "type") == 0 || strcmp(name, "max_entries") == 0) {
+			// member → PTR → ARRAY → btf_array->nelems
+			const struct btf_type *ptr_t = btf__type_by_id(btf, mtype);
+			if (!ptr_t || !btf_is_ptr(ptr_t)) continue;
+			const struct btf_type *arr_t = btf__type_by_id(btf, ptr_t->type);
+			if (!arr_t || !btf_is_array(arr_t)) continue;
+			if (name[0] == 't')  // "type"
+				*map_type = btf_array(arr_t)->nelems;
+			else  // "max_entries"
+				*max_entries = btf_array(arr_t)->nelems;
+		} else if (strcmp(name, "key") == 0 || strcmp(name, "value") == 0) {
+			// member → PTR → target → size
+			const struct btf_type *ptr_t = btf__type_by_id(btf, mtype);
+			if (!ptr_t || !btf_is_ptr(ptr_t)) continue;
+			int resolved = btf_resolve_type(btf, ptr_t->type);
+			const struct btf_type *base = btf__type_by_id(btf, resolved);
+			if (!base) continue;
+			if (name[0] == 'k')  // "key"
+				*key_size = base->size;
+			else  // "value"
+				*value_size = base->size;
+		}
+	}
+}
+
+// 从 BTF 中收集 extern map 变量信息：名称、类型 ID、struct 大小
+int BtfPreprocessor::count_extern_and_get_info(
+    struct btf *btf, std::vector<ExternVarInfo> *ev)
+{
+    auto add = [&](int vid, int sid, int sz, const char *n) {
+        ExternVarInfo x;
+        x.name = n ? n : "";
+        x.var_btf_id = vid;
+        x.struct_btf_id = sid;
+        x.struct_size = sz;
+        x.offset = 0;
+        x.map_type = 0;
+        x.key_size = 0;
+        x.value_size = 0;
+        x.max_entries = 0;
+        fill_map_metadata(btf, sid, &x.map_type, &x.key_size,
+                          &x.value_size, &x.max_entries);
+        ev->push_back(x);
+    };
+    // 先查 .maps DATASEC，再退化为扫描所有 extern struct 变量
+    int sec = btf__find_by_name_kind(btf, ".maps", BTF_KIND_DATASEC);
+    if (sec >= 0) {
+        const struct btf_type *s = btf__type_by_id(btf, sec);
+        const struct btf_var_secinfo *inf = btf_var_secinfos(s);
+        for (int i = 0; i < btf_vlen(s); i++) {
+            const struct btf_type *v = btf__type_by_id(btf, inf[i].type);
+            if (!v||!btf_is_var(v)) continue;
+            if (btf_var(v)->linkage!=BTF_VAR_GLOBAL_EXTERN) continue;
+            const char *n = btf__name_by_offset(btf, v->name_off); if(!n) continue;
+            auto st = btf__type_by_id(btf, v->type);
+            add(inf[i].type, v->type, st ? st->size : 0, n);
+        }
+    } else {
+        int nt = btf__type_cnt(btf);
+        for (int t = 1; t < nt; t++) {
+            const struct btf_type *x = btf__type_by_id(btf, t);
+            if (!x||!btf_is_var(x)) continue;
+            if (btf_var(x)->linkage!=BTF_VAR_GLOBAL_EXTERN) continue;
+            const char *n = btf__name_by_offset(btf, x->name_off); if(!n||!n[0]) continue;
+            auto val = btf__type_by_id(btf, x->type); if(!val||!btf_is_composite(val)) continue;
+            add(t, x->type, val->size, n);
+        }
+    }
+    for (auto &x : *ev) {
+        fprintf(stdout, "  [prep] extern '%s' size=%d map_type=%d "
+                "key_size=%d value_size=%d max_entries=%d\n",
+                x.name.c_str(), x.struct_size, x.map_type,
+                x.key_size, x.value_size, x.max_entries);
+    }
+    return 0;
+}
+
+// 普通文件拷贝，用于生成输出文件副本
+int BtfPreprocessor::copy_file(const char *src, const char *dst)
+{
+    int fi = open(src, O_RDONLY); if (fi<0) return -errno;
+    struct stat st; if (fstat(fi, &st)!=0) { close(fi); return -errno; }
+    int fo = open(dst, O_WRONLY|O_CREAT|O_TRUNC, 0644); if (fo<0) { close(fi); return -errno; }
+    char buf[65536]; ssize_t n;
+    while ((n = read(fi, buf, sizeof(buf))) > 0) { ssize_t w = write(fo, buf, n); if (w!=n) { close(fi); close(fo); return -EIO; } }
+    close(fi); close(fo); return 0;
+}

--- a/tools/btf-preprocessor.h
+++ b/tools/btf-preprocessor.h
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd
+//
+// SPDX-License-Identifier: LGPL-2.1
+
+#ifndef __BTF_PREPROCESSOR_H__
+#define __BTF_PREPROCESSOR_H__
+
+#include <string>
+#include <vector>
+
+#include <bpf/libbpf.h>
+
+/**
+ * @brief 从 BTF 中提取的 extern map 元信息，供 check_extern_maps 返回
+ */
+struct ExternMapInfo {
+    std::string name;
+    std::string type_name;
+    int map_type = 0;
+    __u32 key_size = 0;
+    __u32 value_size = 0;
+    __u32 max_entries = 0;
+    int btf_var_id = 0;
+    int btf_type_id = 0;
+};
+
+/**
+ * @brief 预处理阶段从 extern 声明中提取的每个 map 的元信息
+ *
+ * 包含每个 extern map 变量原始 BTF 类型 ID 和 struct 大小，
+ * 用于 ELF 修改逻辑创建 .maps section 和修复符号表条目。
+ */
+struct ExternVarInfo {
+    std::string name;        ///< 变量名（如 "data_map"）
+    int var_btf_id;          ///< BTF_KIND_VAR 条目的 BTF 类型 ID
+    int struct_btf_id;       ///< 底层 struct 的 BTF 类型 ID
+    int struct_size;         ///< struct 大小（字节，用于 .maps section 数据区）
+    size_t offset;           ///< 在 .maps section 内的偏移（字节）
+    int map_type;            ///< BPF_MAP_TYPE_*（预留，尚未填充）
+    int key_size;            ///< 键大小（字节，预留）
+    int value_size;          ///< 值大小（字节，预留）
+    int max_entries;         ///< 最大条目数（预留）
+};
+
+/**
+ * @brief 预处理含 extern map 声明的 ELF .o 文件
+ *
+ * 执行 ELF 手术将 extern map 声明转为 libbpf 可处理的常规定义。
+ * 转换步骤：
+ *   1. BTF：将 BTF_VAR_GLOBAL_EXTERN 改为 BTF_VAR_GLOBAL_ALLOCATED
+ *   2. BTF：添加 .maps DATASEC，引用这些 extern 变量
+ *   3. 符号表：将 SHN_UNDEF 符号改为指向新的 .maps section
+ *   4. Libelf：创建零初始化的 .maps ELF section
+ *
+ * 预处理后，修补过的 .o 文件可用 bpf_object__open_file() 正常打开，
+ * 由 libbpf 处理。
+ */
+class BtfPreprocessor {
+public:
+    /**
+     * @brief 从 ELF 文件解析 BTF，查找 extern map 变量
+     *
+     * 无需 bpf_object__open_file()（该函数在 extern map 声明时会失败）。
+     * 用于早期检测和向用户展示友好的错误信息。
+     *
+     * @param bpf_obj_path .bpf.o ELF 文件路径
+     * @param ext_info     输出参数，找到的 extern map 信息列表
+     * @return 成功返回 0，解析失败返回负 errno
+     */
+    int check_extern_maps(const char *bpf_obj_path,
+                          std::vector<ExternMapInfo> *ext_info);
+
+    /**
+     * @brief 完整预处理：将 extern map 转为定义
+     *
+     * 在 output_path 创建输入 .o 文件的修补副本，包含：
+     *   - BTF linkage 从 EXTERN 改为 ALLOCATED
+     *   - BTF 中添加 .maps DATASEC（如尚不存在）
+     *   - 创建 .maps ELF section（零填充）
+     *   - 符号表条目更新为指向新的 .maps section
+     *
+     * 修补后的文件可用 bpf_object__open_file() 打开，
+     * 再通过 bpf_map__reuse_fd() 解析 map fd 后加载。
+     *
+     * @param input_path  含 extern 声明的源 .bpf.o 文件
+     * @param output_path 修补后的 .bpf.o 文件输出路径
+     * @param ext_vars    输出参数，已处理的 extern 变量元信息列表
+     * @return 成功返回修补的 extern 变量数量，失败返回负 errno
+     */
+    int preprocess(const char *input_path, const char *output_path,
+                   std::vector<ExternVarInfo> *ext_vars);
+
+    const char *last_error() const { return m_last_error.c_str(); }
+
+private:
+    std::string m_last_error;
+
+    int copy_file(const char *src, const char *dst);
+    int count_extern_and_get_info(struct btf *btf,
+                                  std::vector<ExternVarInfo> *ext_vars);
+};
+
+#endif

--- a/tools/extern-prep.cpp
+++ b/tools/extern-prep.cpp
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd
+//
+// SPDX-License-Identifier: LGPL-2.1
+
+/**
+ * @brief 将 BPF .o 文件中 extern map 声明预处理为定义
+ *
+ * bpftool gen skeleton / libbpf 不支持 extern SEC(".maps")，
+ * 此工具先预处理再喂给 bpftool。
+ *
+ * extern map 名通过自定义 ELF section .extern_map_names 嵌入 .bpf.o，
+ * 运行时由 bpf_linker_resolve_extern() 解析。
+ */
+
+#include <cstdio>
+#include <cstring>
+#include <cstdlib>
+
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+
+#include "btf-preprocessor.h"
+
+// 确保 PinRegistry 文件和锁文件存在
+static void init_pin_registry_files()
+{
+	const char *files[] = {
+		"/var/tmp/.dkapture-pin-registry",
+		"/var/tmp/.dkapture-pin-registry.lock",
+		nullptr
+	};
+	for (int i = 0; files[i]; i++) {
+		int fd = open(files[i], O_CREAT | O_RDWR, 0644);
+		if (fd >= 0) {
+			fchmod(fd, 0644);
+			close(fd);
+		}
+	}
+}
+
+int main(int argc, char *argv[])
+{
+	if (argc < 3) {
+		fprintf(stderr, "Usage: %s <input.bpf.o> <output.bpf.o>\n",
+			argv[0]);
+		return 1;
+	}
+
+	init_pin_registry_files();
+
+	std::vector<ExternVarInfo> ext_vars;
+	BtfPreprocessor preproc;
+	int n = preproc.preprocess(argv[1], argv[2], &ext_vars);
+	if (n < 0) {
+		fprintf(stderr, "Error: %s\n", preproc.last_error());
+		return 1;
+	}
+
+	if (n == 0) {
+		fprintf(stdout, "No extern maps in '%s', copied to '%s'\n",
+			argv[1], argv[2]);
+	} else {
+		fprintf(stdout, "Preprocessed %d extern map(s) in '%s' -> '%s'\n",
+			n, argv[1], argv[2]);
+	}
+	return 0;
+}


### PR DESCRIPTION
Move the extern map preprocessing tool into the bpf repository and build it as part of the bpf tools target.

Run extern-prep immediately after each .bpf.o is produced, then replace the original object in bpf/build/<module>. This makes the generated .bpf.o files the final runtime objects consumed by skeleton generation and packaging.

Also make observe/filter/policy depend on the bpf tools target so extern-prep is available before BPF objects are built.