### PR TITLE
fix(trace-signal): avoid inflight event key collisions

### DIFF
--- a/observe/trace-signal.bpf.c
+++ b/observe/trace-signal.bpf.c
@@ -49,6 +49,14 @@ struct
 
 struct
 {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__type(key, u32);
+	__type(value, struct BpfData);
+	__uint(max_entries, 10240);
+} inflight SEC(".maps");
+
+struct
+{
 	__uint(type, BPF_MAP_TYPE_LRU_HASH);
 	__type(key, pid_t);
 	__type(value, u32);
@@ -142,34 +150,30 @@ struct TpExitKill
 	long ret;
 };
 
-static u32 lkey = __LINE__;
+/*static u32 lkey = __LINE__;*/
 SEC("tracepoint/syscalls/sys_enter_kill")
 int sys_enter_kill(struct TpEnterKill *ctx)
 {
 	long ret;
+	u32 tid;
+    struct BpfData log = {};
 	filter_debug_proc(0, "kill");
-	struct BpfData *log = (typeof(log))malloc_page(lkey);
-	if (!log)
-	{
-		return 0;
-	}
-	log->sender_pid = bpf_get_current_pid_tgid();
-	log->recv_pid = ctx->pid;
-	log->sig = ctx->sig;
-	ret = bpf_get_current_comm(log->sender_comm, sizeof(log->sender_comm));
+	tid = (u32)bpf_get_current_pid_tgid();
+    log.sender_pid = tid;
+    log.recv_pid = ctx->pid;
+    log.sig = ctx->sig;
+
+	ret = bpf_get_current_comm(log.sender_comm, sizeof(log.sender_comm));
 	if (ret)
 	{
 		bpf_err("fail to get current comm: %d", ret);
-		goto exit;
+		return 0;
 	}
-
-	return 0;
-
-exit:
-	if (log)
-	{
-		free_page(lkey);
-	}
+	ret = bpf_map_update_elem(&inflight, &tid, &log, BPF_ANY);
+        if (ret)
+        {
+                bpf_err("fail to update inflight: %ld", ret);
+        }
 	return 0;
 }
 
@@ -183,12 +187,15 @@ int BPF_PROG(
 	int ret
 )
 {
+	u32 tid;
+    struct BpfData *log;
 	if (ret)
 	{
 		return ret;
 	}
 
-	struct BpfData *log = (typeof(log))lookup_page(lkey);
+	 tid = (u32)bpf_get_current_pid_tgid();
+     log = bpf_map_lookup_elem(&inflight, &tid);
 	if (!log)
 	{
 		return 0;
@@ -207,8 +214,11 @@ SEC("tracepoint/syscalls/sys_exit_kill")
 int sys_exit_kill(struct TpExitKill *ctx)
 {
 	long ret;
+	u32 tid;
 	struct Rule *rule;
-	struct BpfData *log = (typeof(log))lookup_page(lkey);
+	struct BpfData *log;
+	tid = (u32)bpf_get_current_pid_tgid();
+    log = bpf_map_lookup_elem(&inflight, &tid);
 	if (!log)
 	{
 		return 0;
@@ -232,7 +242,11 @@ int sys_exit_kill(struct TpExitKill *ctx)
 	}
 
 exit:
-	free_page(lkey);
+	ret = bpf_map_delete_elem(&inflight, &tid);
+	if (ret)
+	{
+			bpf_err("fail to delete inflight: %ld", ret);
+	}
 	return 0;
 }
 


### PR DESCRIPTION
### Bug Description

`trace-signal` 在高频信号场景下会出现如下异常日志：

```text
bpf_trace_printk: error: bpf_map_update_elem: -17
```

同时会导致部分 signal 事件丢失，尤其是在类似 `cpptools-srv -> cpptools` 这种频繁执行 `kill(pid, 0)` 的场景下更容易复现。

---

### Root Cause

问题出在 BPF 侧临时事件缓存使用了 `malloc_page()` / `lookup_page()` / `free_page()` 这一套基于固定 key 的页分配逻辑。

原实现中，`sys_enter_kill` 使用当前 pid 与固定的 `lkey` 拼成唯一 key：

```c
u64 _key = (u64)pid << 32 | key;
```

而 `malloc_page()` 内部使用的是：

```c
bpf_map_update_elem(&__pages, &_key, __page, BPF_NOEXIST);
```

`BPF_NOEXIST` 要求该 key 必须不存在。当同一个进程在前一个 signal 事件还未走到 `sys_exit_kill -> free_page()` 清理时，又再次进入 `sys_enter_kill`，就会因为 key 冲突返回 `-17 (-EEXIST)`。

**后果：**
- 临时缓存申请失败
- 当前 signal 事件无法完整记录
- 用户态看到事件丢失

---

### Problematic Source Code

#### 旧实现：sys_enter_kill

```c
static u32 lkey = __LINE__;

SEC("tracepoint/syscalls/sys_enter_kill")
int sys_enter_kill(struct TpEnterKill *ctx)
{
    long ret;
    filter_debug_proc(0, "kill");
    struct BpfData *log = (typeof(log))malloc_page(lkey);
    if (!log) {
        return 0;
    }
    log->sender_pid = bpf_get_current_pid_tgid();
    log->recv_pid = ctx->pid;
    log->sig = ctx->sig;
    ret = bpf_get_current_comm(log->sender_comm, sizeof(log->sender_comm));
    if (ret) {
        bpf_err("fail to get current comm: %d", ret);
        goto exit;
    }
    return 0;

exit:
    if (log) {
        free_page(lkey);
    }
    return 0;
}
```

#### 具体报错的代码：malloc_page() in mem.h

```c
static char *malloc_page(u32 key)
{
    long ret;
    pid_t pid;
    pid = bpf_get_current_pid_tgid();
    u64 _key = (u64)pid << 32 | key;

    ret = bpf_map_update_elem(&__pages, &_key, __page, BPF_NOEXIST);
    if (ret != 0) {
        bpf_printk("error: bpf_map_update_elem: %ld", ret);
        return NULL;
    }

    char *page = bpf_map_lookup_elem(&__pages, &_key);
    return page;
}
```

---

### Fix Summary

将 trace-signal 的临时事件缓存机制从基于 `mem.h` 的 page 分配方式，替换为专用的 **inflight map**：

-   **key**: 当前线程 tid
-   **value**: `struct BpfData`

**新的处理流程：**

1.  **sys_enter_kill**: 使用 tid 作为 key，将事件骨架写入 inflight
2.  **task_kill**: 从 inflight 中取出该事件，补充接收方 `recv_comm`
3.  **sys_exit_kill**: 从 inflight 中取出事件，补充返回值 `res`，过滤并输出到 ring buffer，最后删除 inflight 中的缓存
4.  **这样处理不报错的原因是**，将malloc_page() in mem.h中的BPF_NOEXIST改成使用inflight map的BPF_ANY了