### PR TITLE
fix(pagefault): add max_entries and value_size for stack trace map

### DIFF
--- a/observe/pagefault.bpf.c
+++ b/observe/pagefault.bpf.c
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd
 //
 // SPDX-License-Identifier: GPL-2.0
-
 #include <vmlinux.h>
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_core_read.h>
@@ -12,6 +11,7 @@
 #define MAX_ENTRIES 1000
 #define MAX_EVENT_SIZE 10240
 #define RINGBUF_SIZE (1024 * 256)
+#define PERF_MAX_STACK_DEPTH 127
 
 const volatile __u64 skip_frame = 0;
 
@@ -32,7 +32,9 @@ struct
 struct
 {
 	__uint(type, BPF_MAP_TYPE_STACK_TRACE);
-	__type(key, u32);
+	__uint(max_entries, MAX_ENTRIES);
+	__uint(key_size, sizeof(u32));
+	__uint(value_size, PERF_MAX_STACK_DEPTH * sizeof(u64));
 } stack_traces SEC(".maps");
 
 struct tp_page_fault_t
@@ -187,3 +189,5 @@ int page_fault_user(struct tp_page_fault_t *ctx)
 
 	return 0;
 }
+// License declaration for BPF program
+char _license[] SEC("license") = "GPL";


### PR DESCRIPTION
### 本次修改主要是修复了由于stack_traces这个map结构不完整导致bpf 验证器不通过，最后工具不能正常使用的问题
1. 报错提示
```cpp
sudo ./build/observe/pagefault -t
libbpf: map 'stack_traces': failed to create: Invalid argument(-22)
libbpf: failed to load object 'pagefault_bpf'
libbpf: failed to load BPF skeleton 'pagefault_bpf': -22
Failed to load BPF skeleton: -22
```
2. 原代码未定义max_entries、value_size导致map结构不完整
```cpp
struct
{
	__uint(type, BPF_MAP_TYPE_STACK_TRACE);
	__type(key, u32);
} stack_traces SEC(".maps");
```
3. 修改后
```cpp
#define PERF_MAX_STACK_DEPTH 127
struct
{
	__uint(type, BPF_MAP_TYPE_STACK_TRACE);
	__uint(max_entries, MAX_ENTRIES);
	__uint(key_size, sizeof(u32));
	__uint(value_size, PERF_MAX_STACK_DEPTH * sizeof(u64))
} stack_traces SEC(".maps");
```
