### PR TITLE
fix: correct ps.bpf.c signal collection and mm field handling

### DIFF
--- a/observe/ps.bpf.c
+++ b/observe/ps.bpf.c
@@ -23,7 +23,7 @@ char _license[] SEC("license") = "GPL";
 struct
 {
 	__uint(type, BPF_MAP_TYPE_RINGBUF);
-	__uint(max_entries, 4 * 1024 * 1024); // 2M
+	__uint(max_entries, 4 * 1024 * 1024); // 4M
 } output SEC(".maps");
 
 #define _NSIG 64
@@ -51,7 +51,7 @@ static void collect_sigign_sigcatch(
 		}
 		else if (k->sa.sa_handler != SIG_DFL)
 		{
-			sigign->sig[0] |= 1UL << (i - 1);
+			sigcatch->sig[0] |= 1UL << (i - 1);
 		}
 	}
 }
@@ -200,11 +200,11 @@ int dump_task(struct bpf_iter__task *ctx)
 
 	dtask->size = BPF_CORE_READ(task, mm, total_vm);
 
-	dtask->resident =
-		dtask->shared + BPF_CORE_READ(task, mm, rss_stat)[MM_ANONPAGES].count;
-
 	dtask->shared = BPF_CORE_READ(task, mm, rss_stat)[MM_FILEPAGES].count +
 					BPF_CORE_READ(task, mm, rss_stat)[MM_SHMEMPAGES].count;
+
+	dtask->resident =
+		dtask->shared + BPF_CORE_READ(task, mm, rss_stat)[MM_ANONPAGES].count;
 
 	dtask->text = (PAGE_ALIGN(BPF_CORE_READ(task, mm, end_data)) -
 				   (BPF_CORE_READ(task, mm, start_data) & PAGE_MASK)) >>


### PR DESCRIPTION
## PR Comment

  这次 `ps.bpf.c` 的修复是必要的，原代码里有两处会直接影响输出正确性：

  1. `collect_sigign_sigcatch()` 里，`SIG_DFL` `SIG_IGN` 之外的信号仍然写进了 `sigign`，导致自定义 handler 的信号永远不会进入 `sigcatch`。
     这会让 `SigIgn` / `SigCgt` 语义混淆，采集结果不可信。

  2. `dump_task()` 里 `resident` 的计算先用了 `dtask->shared`，但 `shared` 是后面才赋值的。
     这会让 `resident` 读到未初始化值，输出结果随机。所以将`shared`的赋值放在`resident`之前。

  这次修复的核心就是：
  - 把“自定义捕获”的信号写到 `sigcatch`
  - 先算 `shared`，再算 `resident`